### PR TITLE
replace obsolete package python-imaging with python-pil

### DIFF
--- a/deblaze.py
+++ b/deblaze.py
@@ -34,7 +34,7 @@ import urllib
 import os, subprocess
 import StringIO
 import base64
-import Image
+from PIL import Image
 import datetime
 
 '''


### PR DESCRIPTION
ref http://git.kali.org/gitweb/?p=packages/deblaze.git;a=commitdiff;h=9403c6d7579887634009810659977810e1aeec97